### PR TITLE
[FEAT] 홈페이지 하단 컴포넌트 구현

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,10 +1,27 @@
+/**
+ * 홈 페이지
+ * 넷플릭스 클론의 메인 페이지로, 다양한 영화 및 TV 프로그램 섹션을 표시합니다.
+ */
+
+import GenrePreview from '@/components/home/GenrePreview';
+import KoreaMovie from '@/components/home/KoreaMovie';
+import NetflixOriginal from '@/components/home/NetflixOriginal';
+import Preview from '@/components/home/Preview';
+import TopRatedMovies from '@/components/home/TopRatedMovies';
 import Header from '@/components/navigation/Header';
 
 const HomePage = () => {
   return (
-    <main className="min-h-screen bg-black text-white">
+    <main className="bg-black text-white">
       <Header />
-      <div className="text-headline1">Home</div>
+      {/* 섹션 컨테이너 */}
+      <div className="flex flex-col gap-[22px] pb-[72px] pt-[44px]">
+        <Preview />
+        <GenrePreview />
+        <NetflixOriginal />
+        <KoreaMovie />
+        <TopRatedMovies />
+      </div>
     </main>
   );
 };

--- a/components/home/GenrePreview.tsx
+++ b/components/home/GenrePreview.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+/**
+ * GenrePreview 섹션 컴포넌트
+ * 특정 장르의 영화를 표시합니다.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { getMoviesByGenre } from '@/apis/home';
+import MovieSwiper from '@/components/home/MovieSwiper';
+import { Movie } from '@/types/tmdb';
+
+const GenrePreview = () => {
+  const [movies, setMovies] = useState<Movie[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMovies = async () => {
+      // 액션(28), 모험(12) 장르 조합
+      const response = await getMoviesByGenre('28,12');
+      setMovies(response.results);
+      setLoading(false);
+    };
+
+    fetchMovies();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return <MovieSwiper title="Action & Adventure Movies" items={movies} itemWidth="103px" itemHeight="177px" />;
+};
+
+export default GenrePreview;

--- a/components/home/KoreaMovie.tsx
+++ b/components/home/KoreaMovie.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * KoreaMovie 섹션 컴포넌트
+ * 한국 영화를 표시합니다.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { getKoreaMovie } from '@/apis/home';
+import MovieSwiper from '@/components/home/MovieSwiper';
+import { Movie } from '@/types/tmdb';
+
+const KoreaMovie = () => {
+  const [movies, setMovies] = useState<Movie[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMovies = async () => {
+      const response = await getKoreaMovie();
+      setMovies(response.results);
+      setLoading(false);
+    };
+
+    fetchMovies();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return <MovieSwiper title="Korea Movies" items={movies} itemWidth="103px" itemHeight="161px" />;
+};
+
+export default KoreaMovie;

--- a/components/home/MovieSwiper.tsx
+++ b/components/home/MovieSwiper.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+/**
+ * MovieSwiper 컴포넌트
+ * Swiper 라이브러리를 사용하여 영화/TV 프로그램 목록을 가로 스크롤 형태로 표시합니다.
+ */
+
+import 'swiper/css';
+import 'swiper/css/free-mode';
+import 'swiper/css/navigation';
+
+import Image from 'next/image';
+import { FreeMode, Navigation } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+import { getImageUrl } from '@/constants/imageURL';
+import { Movie, TV } from '@/types/tmdb';
+
+/**
+ * MovieSwiper Props 인터페이스
+ */
+interface MovieSwiperProps {
+  title: string; // 섹션 제목
+  items: Movie[] | TV[]; // 영화 또는 TV 프로그램 배열
+  itemWidth: string; // 각 아이템의 너비 (예: "103px")
+  itemHeight: string; // 각 아이템의 높이 (예: "161px")
+  shape?: 'rectangle' | 'circle'; // 아이템 모양 (기본값: rectangle)
+}
+
+/**
+ * 영화/TV 프로그램 제목 추출 헬퍼 함수
+ */
+const getTitle = (item: Movie | TV): string => {
+  return 'title' in item ? item.title : item.name;
+};
+
+const MovieSwiper = ({ title, items, itemWidth, itemHeight, shape = 'rectangle' }: MovieSwiperProps) => {
+  return (
+    <div className="w-full">
+      {/* 섹션 제목 */}
+      <h2 className="mb-[14px] px-4 text-headline3 text-white">{title}</h2>
+
+      {/* Swiper 컨테이너 */}
+      <Swiper
+        modules={[FreeMode, Navigation]}
+        spaceBetween={7}
+        slidesPerView="auto"
+        freeMode={true}
+        navigation={false}
+        className="movie-swiper"
+      >
+        {items.map((item) => (
+          <SwiperSlide
+            key={item.id}
+            style={{
+              width: itemWidth,
+              height: itemHeight,
+            }}
+            className="w-auto!"
+          >
+            <div
+              className="relative overflow-hidden bg-gray-800"
+              style={{
+                width: itemWidth,
+                height: itemHeight,
+                borderRadius: shape === 'circle' ? '50%' : '8px',
+              }}
+            >
+              {item.poster_path ? (
+                <Image
+                  src={getImageUrl(item.poster_path, 'LARGE')}
+                  alt={getTitle(item)}
+                  fill
+                  sizes="(max-width: 768px) 50vw, 33vw"
+                  className="object-cover"
+                />
+              ) : (
+                // poster_path가 없을 경우 플레이스홀더
+                <div className="flex h-full w-full items-center justify-center bg-gray-700 text-gray-500">No Image</div>
+              )}
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  );
+};
+
+export default MovieSwiper;

--- a/components/home/NetflixOriginal.tsx
+++ b/components/home/NetflixOriginal.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+/**
+ * NetflixOriginal 섹션 컴포넌트
+ * 넷플릭스 오리지널 TV 프로그램을 표시합니다.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { getTVByNetwork } from '@/apis/home';
+import MovieSwiper from '@/components/home/MovieSwiper';
+import { TV } from '@/types/tmdb';
+
+const NetflixOriginal = () => {
+  const [tvShows, setTvShows] = useState<TV[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchTVShows = async () => {
+      // Netflix 네트워크 ID: 213
+      const response = await getTVByNetwork(213);
+      setTvShows(response.results);
+      setLoading(false);
+    };
+
+    fetchTVShows();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return <MovieSwiper title="Netflix Originals" items={tvShows} itemWidth="154px" itemHeight="251px" />;
+};
+
+export default NetflixOriginal;

--- a/components/home/Preview.tsx
+++ b/components/home/Preview.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * Preview 섹션 컴포넌트
+ * 인기 영화를 원형 이미지로 미리보기 형태로 표시합니다.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { getMoviePopular } from '@/apis/home';
+import MovieSwiper from '@/components/home/MovieSwiper';
+import { Movie } from '@/types/tmdb';
+
+const Preview = () => {
+  const [movies, setMovies] = useState<Movie[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMovies = async () => {
+      const response = await getMoviePopular();
+      setMovies(response.results);
+      setLoading(false);
+    };
+
+    fetchMovies();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return <MovieSwiper title="Previews" items={movies} itemWidth="102px" itemHeight="102px" shape="circle" />;
+};
+
+export default Preview;

--- a/components/home/TopRatedMovies.tsx
+++ b/components/home/TopRatedMovies.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * TopRatedMovies 섹션 컴포넌트
+ * 높은 평점의 영화를 표시합니다.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { getTopRatedMovies } from '@/apis/home';
+import MovieSwiper from '@/components/home/MovieSwiper';
+import { Movie } from '@/types/tmdb';
+
+const TopRatedMovies = () => {
+  const [movies, setMovies] = useState<Movie[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMovies = async () => {
+      const response = await getTopRatedMovies();
+      setMovies(response.results);
+      setLoading(false);
+    };
+
+    fetchMovies();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return <MovieSwiper title="Top Rated Movies" items={movies} itemWidth="103px" itemHeight="161px" />;
+};
+
+export default TopRatedMovies;


### PR DESCRIPTION
### 💡 To Reviewers
- react-swiper 라이브러리 사용했습니다! 
[리액트 스와이퍼 공식문서](https://swiperjs.com/react)

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 메인 페이지 하단 컴포넌트 구현
- 흐름을 설명하자면 MovieSwiper.tsx가 (캐러셀 같은)UI틀이고, 
나머지 컴포넌트들에서 어떤 api를 사용해서 데이터를 받아올지, 그리고 width나 height 등은 어떻게 할지 정해서 받습니다.

### 데이터 흐름 (Data Flow)
1. 섹션 컴포넌트 마운트   
2. useEffect 실행 → API 호출   
3. 데이터 받아서 state에 저장   
4. MovieSwiper에 props로 전달   
{     title: "Previews",     items: [영화1, 영화2, 영화3...],     itemWidth: "102px",     itemHeight: "102px",     shape: "circle"   }   
5. MovieSwiper가 props 받아서 UI 렌더링   
- 제목 표시   
- Swiper로 가로 스크롤   
- 각 영화를 이미지로 표시

### 🤔 추후 작업 예정
- 각 영화 클릭하면 deatil페이지로 링크되도록 리팩토

### 📸 작업 결과 (스크린샷)

https://github.com/user-attachments/assets/c7c6beb9-2956-4256-8371-e5540e404b51


### 🔗 관련 이슈
- #9 
