### PR TITLE
[FEAT] 상세 페이지 구현 및 API 연동

### DIFF
--- a/src/app/detail/[mediaType]/[id]/page.tsx
+++ b/src/app/detail/[mediaType]/[id]/page.tsx
@@ -20,7 +20,7 @@ const DetailPage = async ({ params }: { params: Promise<{ mediaType: string; id:
   const overviewText = (detail.overview || '').trim();
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="bg-black text-white">
       {/* 포스터 이미지 */}
       {detail.poster_path && (
         <div className="relative w-full h-[415px]">
@@ -30,7 +30,7 @@ const DetailPage = async ({ params }: { params: Promise<{ mediaType: string; id:
       )}
       {/* 재생 버튼 */}
       <div className="flex justify-center items-center mb-8">
-        <button className="bg-gray-100 text-black mx-6 px-8 h-[45px] w-[303px] rounded-[5.63px] inline-flex items-center justify-center gap-2 text-subhead1 leading-none hover:bg-gray-200 transition cursor-pointer">
+        <button className="bg-gray-100 text-black mx-6 px-8 h-[45px] w-[303px] rounded-[5.63px] inline-flex items-center justify-center gap-2 text-subhead1 leading-none cursor-pointer">
           <PlayIcon className="w-[18px] h-[21.6px] shrink-0" />
           <span className="text-subhead1 leading-none align-middle">Play</span>
         </button>

--- a/src/app/detail/[mediaType]/[id]/page.tsx
+++ b/src/app/detail/[mediaType]/[id]/page.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+
+import { getImageUrl } from '@/constants/imageURL';
+import { getDetail } from '@/lib/api/tmdb/detail';
+import PlayIcon from '@/svgs/navigation/playIcon.svg';
+
+const DetailPage = async ({ params }: { params: Promise<{ mediaType: string; id: string }> }) => {
+  const { mediaType, id } = await params;
+  const detail = await getDetail(mediaType, id);
+
+  if (!detail) {
+    return (
+      <div className="min-h-screen bg-black text-white p-4 flex items-center justify-center">
+        <p>정보를 불러올 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  const title = 'title' in detail ? detail.title : detail.name;
+  const overviewText = (detail.overview || '').trim();
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      {/* 포스터 이미지 */}
+      {detail.poster_path && (
+        <div className="relative w-full h-[415px]">
+          <Image src={getImageUrl(detail.poster_path, 'ORIGINAL')} alt={title} fill className="object-cover" priority />
+          <div className="absolute inset-0 bg-linear-to-t from-black via-black/45 to-transparent" />
+        </div>
+      )}
+      {/* 재생 버튼 */}
+      <div className="flex justify-center items-center mb-8">
+        <button className="bg-gray-100 text-black mx-6 px-8 h-[45px] w-[303px] rounded-[5.63px] inline-flex items-center justify-center gap-2 text-subhead1 leading-none hover:bg-gray-200 transition cursor-pointer">
+          <PlayIcon className="w-[18px] h-[21.6px] shrink-0" />
+          <span className="text-subhead1 leading-none align-middle">Play</span>
+        </button>
+      </div>
+      {/* 상세 정보 */}
+      <div className="relative px-8 pb-4">
+        <h1 className="text-headline2 font-bold mb-4">Previews</h1>
+        {overviewText ? (
+          <p className="text-caption3">{overviewText}</p>
+        ) : (
+          <p className="text-caption3">줄거리가 따로 제공되지 않습니다.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DetailPage;

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -3,7 +3,6 @@
  * 넷플릭스 클론의 메인 페이지로, 다양한 영화 및 TV 프로그램 섹션을 표시합니다.
  */
 
-import PlayBar from '@/components/home/client/PlayBar';
 import GenrePreview from '@/components/home/server/GenrePreview';
 import KoreaMovie from '@/components/home/server/KoreaMovie';
 import NetflixOriginal from '@/components/home/server/NetflixOriginal';
@@ -17,7 +16,6 @@ const HomePage = () => {
     <main className="bg-black text-white">
       <Header />
       <TrendingMovies />
-      <PlayBar />
       {/* 섹션 컨테이너 */}
       <div className="flex flex-col gap-[22px] pb-[72px] pt-11">
         <Preview />

--- a/src/components/home/client/MovieSwiper.tsx
+++ b/src/components/home/client/MovieSwiper.tsx
@@ -36,7 +36,7 @@ const getTitle = (item: Movie | TV): string => {
 };
 
 /**
- * 미디어 타입 확인 헬퍼 함수
+ * 미디어 타입 확인 헬퍼 함수 (movie: title 속성 존재 시, tv: name 속성 존재 시)
  */
 const getMediaType = (item: Movie | TV): 'movie' | 'tv' => {
   return 'title' in item ? 'movie' : 'tv';

--- a/src/components/home/client/MovieSwiper.tsx
+++ b/src/components/home/client/MovieSwiper.tsx
@@ -10,6 +10,7 @@ import 'swiper/css/free-mode';
 import 'swiper/css/navigation';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { FreeMode, Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
@@ -34,6 +35,13 @@ const getTitle = (item: Movie | TV): string => {
   return 'title' in item ? item.title : item.name;
 };
 
+/**
+ * 미디어 타입 확인 헬퍼 함수
+ */
+const getMediaType = (item: Movie | TV): 'movie' | 'tv' => {
+  return 'title' in item ? 'movie' : 'tv';
+};
+
 const MovieSwiper = ({ title, items, itemWidth, itemHeight, shape = 'rectangle' }: MovieSwiperProps) => {
   return (
     <div className="w-full">
@@ -51,23 +59,25 @@ const MovieSwiper = ({ title, items, itemWidth, itemHeight, shape = 'rectangle' 
       >
         {items.map((item) => (
           <SwiperSlide key={item.id} style={{ width: itemWidth, height: itemHeight }} className="w-auto!">
-            <div
+            <Link href={`/detail/${getMediaType(item)}/${item.id}`}>
+              <div
               className="relative overflow-hidden bg-gray-800"
-              style={{ width: itemWidth, height: itemHeight, borderRadius: shape === 'circle' ? '50%' : '8px' }}
-            >
-              {item.poster_path ? (
-                <Image
-                  src={getImageUrl(item.poster_path, 'LARGE')}
-                  alt={getTitle(item)}
-                  fill
-                  sizes="(max-width: 768px) 50vw, 33vw"
-                  className="object-cover"
-                />
-              ) : (
-                // poster_path가 없을 경우 플레이스홀더
-                <div className="flex h-full w-full items-center justify-center bg-gray-700 text-gray-500">No Image</div>
-              )}
-            </div>
+                style={{ width: itemWidth, height: itemHeight, borderRadius: shape === 'circle' ? '50%' : '8px' }}
+              >
+                {item.poster_path ? (
+                  <Image
+                    src={getImageUrl(item.poster_path, 'LARGE')}
+                    alt={getTitle(item)}
+                    fill
+                    sizes="(max-width: 768px) 50vw, 33vw"
+                    className="object-cover"
+                  />
+                ) : (
+                  // poster_path가 없을 경우 플레이스홀더
+                  <div className="flex h-full w-full items-center justify-center bg-gray-700 text-gray-500">No Image</div>
+                )}
+              </div>
+            </Link>
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/components/home/client/PlayBar.tsx
+++ b/src/components/home/client/PlayBar.tsx
@@ -7,8 +7,8 @@ import InfoIcon from '@/svgs/navigation/infoIcon.svg';
 import PlayIcon from '@/svgs/navigation/playIcon.svg';
 
 interface PlayBarProps {
-  mediaId: number; // 항상 존재
-  mediaType?: 'movie' | 'tv'; // 기본 movie
+  mediaId: number;
+  mediaType?: 'movie' | 'tv';
 }
 
 const PlayBar = ({ mediaId, mediaType = 'movie' }: PlayBarProps) => {

--- a/src/components/home/client/PlayBar.tsx
+++ b/src/components/home/client/PlayBar.tsx
@@ -1,24 +1,35 @@
 'use client';
 
+import Link from 'next/link';
+
 import AddIcon from '@/svgs/navigation/addIcon.svg';
 import InfoIcon from '@/svgs/navigation/infoIcon.svg';
 import PlayIcon from '@/svgs/navigation/playIcon.svg';
 
-const PlayBar = () => {
+interface PlayBarProps {
+  mediaId: number; // 항상 존재
+  mediaType?: 'movie' | 'tv'; // 기본 movie
+}
+
+const PlayBar = ({ mediaId, mediaType = 'movie' }: PlayBarProps) => {
   return (
     <div className="flex items-center justify-center gap-[42px]">
       <div className="flex flex-col items-center cursor-pointer">
         <AddIcon className="w-6 h-6" />
         <span className="text-body3 mt-0.5">My List</span>
       </div>
-      <button className="bg-gray-100 text-black px-6 py-2 rounded-[5.63px] flex items-center gap-2 text-subhead1 hover:bg-gray-200 transition cursor-pointer">
+      <button className="bg-gray-100 text-black px-6 py-2 rounded-[5.63px] flex items-center gap-2 text-subhead1 cursor-pointer">
         <PlayIcon className="w-[18px] h-[21.6px]" />
         Play
       </button>
-      <div className="flex flex-col items-center cursor-pointer">
+      <Link
+        href={`/detail/${mediaType}/${mediaId}`}
+        aria-label="More Info"
+        className="flex flex-col items-center cursor-pointer"
+      >
         <InfoIcon className="w-6 h-6" />
         <span className="text-body3 mt-0.5">Info</span>
-      </div>
+      </Link>
     </div>
   );
 };

--- a/src/components/home/client/TrendingBanner.tsx
+++ b/src/components/home/client/TrendingBanner.tsx
@@ -81,6 +81,7 @@ const TrendingBanner = ({ items }: TrendingBannerProps) => {
           </span>
         </div>
       </div>
+      {/* PlayBar 컴포넌트 이동 (상세페이지로 이동 가능) */}
       <div className="mt-4">
         <PlayBar mediaId={currentItem.id} mediaType={currentItem.media_type ?? 'movie'} />
       </div>

--- a/src/components/home/client/TrendingBanner.tsx
+++ b/src/components/home/client/TrendingBanner.tsx
@@ -9,6 +9,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
+import PlayBar from '@/components/home/client/PlayBar';
 import { getImageUrl } from '@/constants/imageURL';
 import { Movie } from '@/types/tmdb';
 
@@ -79,6 +80,9 @@ const TrendingBanner = ({ items }: TrendingBannerProps) => {
             #{currentIndex + 1} in Korea Today
           </span>
         </div>
+      </div>
+      <div className="mt-4">
+        <PlayBar mediaId={currentItem.id} mediaType={currentItem.media_type ?? 'movie'} />
       </div>
     </section>
   );


### PR DESCRIPTION
### 💡 To Reviewers
- movie swiper의 각 아이템과 trending banner 내 info 버튼에서 상세페이지로 이동하도록 link 사용하였습니다.
- api 함수의 형식과 동일하게 동적 라우팅 경로 또한 detail/[mediaType]/[id]/page.tsx 로 하였습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 영화 상세 페이지 UI 구현
- 상세 페이지 API 연동
- 홈에서 상세페이지로 이동 구현

### 🤔 추후 작업 예정
- 검색페이지에서 상세페이지로 이동하는 것 구현되어야합니다..!

### 📸 작업 결과 (스크린샷)

https://github.com/user-attachments/assets/f8558604-9505-4fd9-8f8d-ce156394f4ff

### 🔗 관련 이슈
- close: #16 
