### PR TITLE
[FEAT] 검색 페이지->상세 페이지 Link 연결

### DIFF
--- a/src/components/home/client/MovieSwiper.tsx
+++ b/src/components/home/client/MovieSwiper.tsx
@@ -15,6 +15,7 @@ import { FreeMode, Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import { getImageUrl } from '@/constants/imageURL';
+import { getMediaTitle, getMediaType } from '@/lib/utils/media';
 import { Movie, TV } from '@/types/tmdb';
 
 /**
@@ -27,20 +28,6 @@ interface MovieSwiperProps {
   itemHeight: string; // 각 아이템의 높이 (예: "161px")
   shape?: 'rectangle' | 'circle'; // 아이템 모양 (기본값: rectangle)
 }
-
-/**
- * 영화/TV 프로그램 제목 추출 헬퍼 함수
- */
-const getTitle = (item: Movie | TV): string => {
-  return 'title' in item ? item.title : item.name;
-};
-
-/**
- * 미디어 타입 확인 헬퍼 함수 (movie: title 속성 존재 시, tv: name 속성 존재 시)
- */
-const getMediaType = (item: Movie | TV): 'movie' | 'tv' => {
-  return 'title' in item ? 'movie' : 'tv';
-};
 
 const MovieSwiper = ({ title, items, itemWidth, itemHeight, shape = 'rectangle' }: MovieSwiperProps) => {
   return (
@@ -61,20 +48,22 @@ const MovieSwiper = ({ title, items, itemWidth, itemHeight, shape = 'rectangle' 
           <SwiperSlide key={item.id} style={{ width: itemWidth, height: itemHeight }} className="w-auto!">
             <Link href={`/detail/${getMediaType(item)}/${item.id}`}>
               <div
-              className="relative overflow-hidden bg-gray-800"
+                className="relative overflow-hidden bg-gray-800"
                 style={{ width: itemWidth, height: itemHeight, borderRadius: shape === 'circle' ? '50%' : '8px' }}
               >
                 {item.poster_path ? (
                   <Image
                     src={getImageUrl(item.poster_path, 'LARGE')}
-                    alt={getTitle(item)}
+                    alt={getMediaTitle(item)}
                     fill
                     sizes="(max-width: 768px) 50vw, 33vw"
                     className="object-cover"
                   />
                 ) : (
                   // poster_path가 없을 경우 플레이스홀더
-                  <div className="flex h-full w-full items-center justify-center bg-gray-700 text-gray-500">No Image</div>
+                  <div className="flex h-full w-full items-center justify-center bg-gray-700 text-gray-500">
+                    No Image
+                  </div>
                 )}
               </div>
             </Link>

--- a/src/components/home/client/TrendingBanner.tsx
+++ b/src/components/home/client/TrendingBanner.tsx
@@ -83,7 +83,7 @@ const TrendingBanner = ({ items }: TrendingBannerProps) => {
       </div>
       {/* PlayBar 컴포넌트 이동 (상세페이지로 이동 가능) */}
       <div className="mt-4">
-        <PlayBar mediaId={currentItem.id} mediaType={currentItem.media_type ?? 'movie'} />
+        <PlayBar mediaId={currentItem.id} mediaType="movie" />
       </div>
     </section>
   );

--- a/src/components/search/client/MediaCard.tsx
+++ b/src/components/search/client/MediaCard.tsx
@@ -12,7 +12,7 @@ interface MediaCardProps {
 
 const MediaCard = ({ item }: MediaCardProps) => {
   return (
-    <Link href={`/detail/${getMediaType(item)}/${item.id}`}>
+    <Link href={`/detail/${getMediaType(item)}/${item.id}`} className="block">
       <div className="h-[76px] flex items-center relative overflow-hidden bg-gray-300">
         {/* 이미지 */}
         <div className="w-[146px] h-[76px] relative shrink-0">

--- a/src/components/search/client/MediaCard.tsx
+++ b/src/components/search/client/MediaCard.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { getImageUrl } from '@/constants/imageURL';
-import { getMediaTitle } from '@/lib/utils/media';
+import { getMediaTitle, getMediaType } from '@/lib/utils/media';
 import PlayButton from '@/svgs/search/playButton.svg';
 import type { Media } from '@/types/tmdb';
 
@@ -12,7 +12,7 @@ interface MediaCardProps {
 
 const MediaCard = ({ item }: MediaCardProps) => {
   return (
-    <Link href={`/detail/${item.media_type}/${item.id}`}>
+    <Link href={`/detail/${getMediaType(item)}/${item.id}`}>
       <div className="h-[76px] flex items-center relative overflow-hidden bg-gray-300">
         {/* 이미지 */}
         <div className="w-[146px] h-[76px] relative shrink-0">

--- a/src/components/search/client/MediaCard.tsx
+++ b/src/components/search/client/MediaCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import { getImageUrl } from '@/constants/imageURL';
 import { getMediaTitle } from '@/lib/utils/media';
@@ -11,24 +12,26 @@ interface MediaCardProps {
 
 const MediaCard = ({ item }: MediaCardProps) => {
   return (
-    <div className="h-[76px] flex items-center relative overflow-hidden bg-gray-300">
-      {/* 이미지 */}
-      <div className="w-[146px] h-[76px] relative shrink-0">
-        <Image
-          src={getImageUrl(item.poster_path, 'SMALL') || '/placeholder.png'}
-          alt={getMediaTitle(item)}
-          fill
-          sizes="146px"
-          className="object-cover"
-        />
-      </div>
+    <Link href={`/detail/${item.media_type}/${item.id}`}>
+      <div className="h-[76px] flex items-center relative overflow-hidden bg-gray-300">
+        {/* 이미지 */}
+        <div className="w-[146px] h-[76px] relative shrink-0">
+          <Image
+            src={getImageUrl(item.poster_path, 'SMALL') || '/placeholder.png'}
+            alt={getMediaTitle(item)}
+            fill
+            sizes="146px"
+            className="object-cover"
+          />
+        </div>
 
-      {/* 제목 및 재생 버튼 */}
-      <div className="flex-1 flex items-center justify-between px-[19px]">
-        <h3 className="text-body2 text-white flex-1">{getMediaTitle(item)}</h3>
-        <PlayButton className="w-7 h-7" />
+        {/* 제목 및 재생 버튼 */}
+        <div className="flex-1 flex items-center justify-between px-[19px]">
+          <h3 className="text-body2 text-white flex-1">{getMediaTitle(item)}</h3>
+          <PlayButton className="w-7 h-7" />
+        </div>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/search/client/SearchResults.tsx
+++ b/src/components/search/client/SearchResults.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 
 import MediaCard from '@/components/search/client/MediaCard';
 import { searchMulti } from '@/lib/api/tmdb/search';
+import { removeDuplicateMedia } from '@/lib/utils/media';
 import type { Media } from '@/types/tmdb';
 
 interface SearchResultsProps {
@@ -69,7 +70,10 @@ const SearchResults = ({ query }: SearchResultsProps) => {
   // 배우(person) 제외, 영화와 TV만 포함
   const allResults = data?.pages.flatMap((page) => page.results.filter((item) => item.media_type !== 'person')) || [];
 
-  if (allResults.length === 0) {
+  // 중복 제거
+  const uniqueResults = removeDuplicateMedia(allResults);
+
+  if (uniqueResults.length === 0) {
     return (
       <div className="px-5 py-10 text-center">
         <p className="text-white">No results found</p>
@@ -81,7 +85,7 @@ const SearchResults = ({ query }: SearchResultsProps) => {
     <div>
       <h2 className="py-[21px] text-headline2 text-white">Search Results</h2>
       <div className="space-y-[2px]">
-        {allResults.map((item) => (
+        {uniqueResults.map((item) => (
           <MediaCard key={`${item.id}-${item.media_type}`} item={item as Media} />
         ))}
       </div>

--- a/src/components/search/client/TopSearches.tsx
+++ b/src/components/search/client/TopSearches.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react';
 
 import MediaCard from '@/components/search/client/MediaCard';
 import { getTrendingAllDay } from '@/lib/api/tmdb/home';
+import { removeDuplicateMedia } from '@/lib/utils/media';
 import type { Media } from '@/types/tmdb';
 
 const TopSearches = () => {
@@ -61,7 +62,10 @@ const TopSearches = () => {
 
   const allResults = data.pages.flatMap((page) => page.results) || [];
 
-  if (allResults.length === 0) {
+  // 중복 제거
+  const uniqueResults = removeDuplicateMedia(allResults as Media[]);
+
+  if (uniqueResults.length === 0) {
     return null;
   }
 
@@ -69,7 +73,7 @@ const TopSearches = () => {
     <div>
       <h2 className="py-[21px] text-headline2 text-white">Top Searches</h2>
       <div className="space-y-[2px]">
-        {allResults.map((item) => (
+        {uniqueResults.map((item) => (
           <MediaCard key={`${item.id}-${item.media_type || 'unknown'}`} item={item as Media} />
         ))}
       </div>

--- a/src/lib/utils/media.ts
+++ b/src/lib/utils/media.ts
@@ -10,3 +10,12 @@ export const getMediaTitle = (item: Media): string => {
   if ('name' in item) return item.name;
   return 'Unknown';
 };
+
+/**
+ * Media 객체에서 미디어 타입을 추출하는 유틸리티 함수
+ * @param item - Movie 또는 TV 객체
+ * @returns 미디어 타입 ('movie' | 'tv')
+ */
+export const getMediaType = (item: Media): 'movie' | 'tv' => {
+  return 'title' in item ? 'movie' : 'tv';
+};

--- a/src/lib/utils/media.ts
+++ b/src/lib/utils/media.ts
@@ -19,3 +19,14 @@ export const getMediaTitle = (item: Media): string => {
 export const getMediaType = (item: Media): 'movie' | 'tv' => {
   return 'title' in item ? 'movie' : 'tv';
 };
+
+/**
+ * Media 배열에서 중복을 제거하는 유틸리티 함수
+ * @param items - Media 객체 배열
+ * @returns 중복이 제거된 Media 객체 배열
+ */
+export const removeDuplicateMedia = (items: Media[]): Media[] => {
+  return items.filter(
+    (item, index, self) => index === self.findIndex((t) => t.id === item.id && t.media_type === item.media_type),
+  );
+};


### PR DESCRIPTION
### 💡 To Reviewers
- src/lib/utils/media.ts에 공통 유틸리티 함수들(getMediaType, removeDuplicateMedia)을 추가하였습니다.
- Link 컴포넌트에 block 클래스를 추가하여 space-y 간격이 제대로 적용되도록 수정했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
## 1. 검색 결과 → Detail 페이지 네비게이션 구현
- MediaCard 컴포넌트에 Next.js Link 추가
- 클릭 시 /detail/${mediaType}/${id} 경로로 이동
- Link에 className="block" 추가하여 간격 문제 해결

## 2. 미디어 관련 유틸리티 함수 통합 (src/lib/utils/media.ts)
- getMediaType: 미디어 타입 추출 함수 추가
- MovieSwiper.tsx의 중복 로직 제거 및 공통 함수 사용
- removeDuplicateMedia: 무한 스크롤에서 발생하는 중복 데이터 제거 함수 추가
- SearchResults.tsx와 TopSearches.tsx의 중복 로직 제거

## 3. 에러 해결
- React key 중복 에러 해결 (중복 제거 로직 적용)

### 🤔 추후 작업 예정
- Tanstack query 관련 로직 분리
- 폰트 및 Skeleton UI 최적화

### 📸 작업 결과 (스크린샷)
https://github.com/user-attachments/assets/599bab2a-a257-4d56-8f14-6e3347aa2070

### 🔗 관련 이슈
- #19 
